### PR TITLE
Link to https://mailcoach.app/docs/package/using-the-ui/authorizing-u…

### DIFF
--- a/docs/package/general/installation-and-setup.md
+++ b/docs/package/general/installation-and-setup.md
@@ -274,7 +274,7 @@ In the `config/queue.php` file you must add the `mailcoach-redis` connection:
 
 ## Add authorization to Mailcoach UI
 
-By default you can only use the Mailcoach on a local environment. To use it in other environment you need to register an gate check. Head over to [the section on authorizing users](docs/package/using-the-ui/authorizing-users) to learn more.
+By default you can only use the Mailcoach on a local environment. To use it in other environment you need to register an gate check. Head over to [the section on authorizing users](/docs/package/using-the-ui/authorizing-users) to learn more.
 
 ## Visit the UI
 


### PR DESCRIPTION
…sers was broken

Hopefully adding a leading `/` fixes the problem and correctly links to https://mailcoach.app/docs/package/using-the-ui/authorizing-users (I'm new to this.)