### PR TITLE
Permanently deleting a subscriber seems wrong in the docs...

### DIFF
--- a/docs/package/working-with-lists/unsubscribing-from-a-list.md
+++ b/docs/package/working-with-lists/unsubscribing-from-a-list.md
@@ -37,14 +37,9 @@ Emails sent have the ```List-Unsubscribe``` header included. This allows for use
 
 ## Permanently deleting a subscriber
 
-Behind the scenes, the subscriber and the subscription will not be deleted. Instead, the status of the subscription will be updated to `unsubscribed`.
-If you want to delete a subscription outright, you can call `delete` on it.
+Behind the scenes, the subscriber won't be deleted. Instead, the status of the subscription will be updated to `unsubscribed`.
 
-```php
-$emailList->getSubscription('john@example.com')->delete();
-```
-
-If you want to delete a subscriber entirely, you can call `delete` on it.
+If you want to delete a the subscription/subscriber entirely, you can call `delete` on it.
 
 ```php
 Subscriber::findForEmail('john@example.com')->delete();

--- a/docs/package/working-with-lists/unsubscribing-from-a-list.md
+++ b/docs/package/working-with-lists/unsubscribing-from-a-list.md
@@ -39,7 +39,7 @@ Emails sent have the ```List-Unsubscribe``` header included. This allows for use
 
 Behind the scenes, the subscriber won't be deleted. Instead, the status of the subscription will be updated to `unsubscribed`.
 
-If you want to delete a the subscription/subscriber entirely, you can call `delete` on it.
+If you want to delete the subscription/subscriber entirely, you can call `delete` on it.
 
 ```php
 Subscriber::findForEmail('john@example.com')->delete();


### PR DESCRIPTION
I've rewritten the delete section slightly as it was a bit confusing.

But mainly the first code example didn't exist in Mailcoach, as far as I can see - so I removed it.

The very last line isn't very clear either. Seems to be that the code example that's left just gets the Subscriber model and calls delete, which is an Eloquent method. The only thing I can think this refers to is that by deleting a Subscriber, you will also be deleting all their stats (due tot he cascades defined in the migration file).

I'm not sure what to update that last line to - so have left as is...