### PR TITLE
Correct schedule commands

### DIFF
--- a/docs/package/general/installation-and-setup.md
+++ b/docs/package/general/installation-and-setup.md
@@ -80,8 +80,8 @@ protected function schedule(Schedule $schedule)
     // ...
     $schedule->command('mailcoach:calculate-statistics')->everyMinute();
     $schedule->command('mailcoach:send-scheduled-campaigns')->everyMinute();
-    $schedule->command('mailcoach:send-campaign-summary-mails')->hourly();
-    $schedule->command('mailcoach:send-email-list-summary-mail ')->mondays()->at('9:00');
+    $schedule->command('mailcoach:send-campaign-summary-mail')->hourly();
+    $schedule->command('mailcoach:send-email-list-summary-mail')->mondays()->at('9:00');
     $schedule->command('mailcoach:delete-old-unconfirmed-subscribers')->daily();
 }
 ```


### PR DESCRIPTION
There is no command for `mailcoach:send-campaign-summary-mails`