### PR TITLE
fix laravel.com docs URL

### DIFF
--- a/docs/package/advanced-usage/using-custom-mailables.md
+++ b/docs/package/advanced-usage/using-custom-mailables.md
@@ -2,7 +2,7 @@
 title: Using custom mailables
 ---
 
-You can use your own [mailable](https://laravel.com/docs/v2/master/mail#writing-mailables) to be used when sending a campaign. Any mailable that extends `Spatie\Mailcoach\Mails\CampaignMailable` is valid.
+You can use your own [mailable](https://laravel.com/docs/master/mail#writing-mailables) to be used when sending a campaign. Any mailable that extends `Spatie\Mailcoach\Mails\CampaignMailable` is valid.
 
 Here's an example mailable;
 

--- a/docs/package/handling-feedback/amazon-ses.md
+++ b/docs/package/handling-feedback/amazon-ses.md
@@ -85,5 +85,5 @@ Here's an example for a configuration set that is named `mailcoach`:
 
 ## Using the correct mail driver
 
-If you haven't done so already, you must configure Laravel to use the Amazon SES driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/v2/master/mail#driver-prerequisites).
+If you haven't done so already, you must configure Laravel to use the Amazon SES driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/master/mail#driver-prerequisites).
 

--- a/docs/package/handling-feedback/mailgun.md
+++ b/docs/package/handling-feedback/mailgun.md
@@ -64,7 +64,7 @@ You must use this route macro somewhere in your routes file. Replace `'mailgun-f
 
 ## Using the correct mail driver
 
-If you haven't done so already, you must configure Laravel to use the Mailgun driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/v2/master/mail#driver-prerequisites).
+If you haven't done so already, you must configure Laravel to use the Mailgun driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/master/mail#driver-prerequisites).
 
 ## Informing Mailgun 
 

--- a/docs/package/handling-feedback/postmark.md
+++ b/docs/package/handling-feedback/postmark.md
@@ -70,7 +70,7 @@ POSTMARK_SIGNING_SECRET=
 
 ## Using the correct mail driver
 
-If you haven't done so already, you must configure Laravel to use the Postmark driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/v2/master/mail#driver-prerequisites).
+If you haven't done so already, you must configure Laravel to use the Postmark driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/master/mail#driver-prerequisites).
 
 ## Informing Postmark 
 

--- a/docs/package/handling-feedback/sendgrid.md
+++ b/docs/package/handling-feedback/sendgrid.md
@@ -61,7 +61,7 @@ In your `.env` you must add a key `SENDGRID_SIGNING_SECRET` with the Sendgrid si
 
 ## Using the correct mail driver
 
-If you haven't done so already, you must configure Laravel to use the Sendgrid driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/v2/master/mail#driver-prerequisites).
+If you haven't done so already, you must configure Laravel to use the Sendgrid driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/master/mail#driver-prerequisites).
 
 ## Informing Sendgrid 
 

--- a/docs/package/working-with-lists/subscribing-to-a-list.md
+++ b/docs/package/working-with-lists/subscribing-to-a-list.md
@@ -38,7 +38,7 @@ Subscriber::createWithEmail('john@example.com')
 
 ## Adding regular attributes
 
-If you need more attributes on a subscriber you can create [a migration](https://laravel.com/docs/v2/master/migrations) that adds a field.
+If you need more attributes on a subscriber you can create [a migration](https://laravel.com/docs/master/migrations) that adds a field.
 
 ```php
 Schema::table('mailcoach_subscribers', function (Blueprint $table) {


### PR DESCRIPTION
Some URLs that link to Laravel docs are broken. Here's a PR to fix those.

