### PR TITLE
emailList name is Subscriber relationship

### DIFF
--- a/docs/package/advanced-usage/handling-events.md
+++ b/docs/package/advanced-usage/handling-events.md
@@ -19,7 +19,7 @@ $email = $event->subcriber->email;
 This is how to get the name of the email list:
 
 ```php
-$nameOfEmailList = $event->emailList->name;
+$nameOfEmailList = $event->subscriber->emailList->name;
 ```
 
 ## `Spatie\Mailcoach\Events\UnconfirmedSubscriberCreatedEvent`


### PR DESCRIPTION
Currently the email list name is defined as `name` on the emailList object, while the `SubscriberEvent` event only has the `Subscriber` object. Getting the email list name should be done through the `emailList` relationship on the `Subscriber` object.