### PR TITLE
Provide clarity on how attributes are set upon creation

### DIFF
--- a/docs/package/working-with-lists/creating-a-list.md
+++ b/docs/package/working-with-lists/creating-a-list.md
@@ -27,6 +27,8 @@ When sending a campaign to this email list these defaults will be used if you se
 
 By default, Mailcoach sends all mails using the default mailer of your Laravel app. In the `mailcoach.php` config file, [you can override this](https://mailcoach.app/docs/v2/package/general/installation-and-setup#configure-an-email-sending-service).
 
+At the time of creating your EmailList, the `transactional_mailer` and `campaign_mailer` attributes will be set based on your configuration settings. Any future change in your configuration settings will not automatically apply to the EmailList.
+
 You can also override the mailer to be used on the list level by updating the `campaign_mailer` attribute with the mailer to be used. Confirmation and welcome mails will be sent using the mailer specified in `transactional_mailer`.
 
 ```php


### PR DESCRIPTION
These docs are not clear that attributes are set based on the config values at the time of EmailList creation. This caused me a lot of trouble, so I'm hoping this docs change provides clarity for others.

To me, it would be more intuitive for the app to use the config values on the EmailList and leave the attributes set to `null`. I would only set this value if the user chose to override the default. By setting these values on the creation of every EmailList, that means if have a large number of lists and want to change my mailer for all of them, I have to change the attribute on each list instead of just changing my config value.