### PR TITLE
Remove duplicate sentence

### DIFF
--- a/docs/package/handling-feedback/mailgun.md
+++ b/docs/package/handling-feedback/mailgun.md
@@ -60,8 +60,6 @@ In the `mailcoach` config file you must add this section.
 
 In your `.env` you must add a key `MAILGUN_SIGNING_SECRET` with the Mailgun signing secret you'll find at the Mailgun dashboard as its value. 
 
-You must use this route macro somewhere in your routes file. Replace `'mailgun-feeback'` with the url you specified at Mailgun when setting up the webhook there.
-
 ## Using the correct mail driver
 
 If you haven't done so already, you must configure Laravel to use the Mailgun driver. Follow the instruction in [the mail section of the Laravel docs](https://laravel.com/docs/7.x/mail#driver-prerequisites).


### PR DESCRIPTION
Under 'Adding the webhooks route' it says:

> You must use this route macro in your route service provider. We recommend to not apply the web group middleware to this route as that would cause an unnecessary session to be started for each webhook call. You can replace mailgun-feedback with any url you'd like.

Then further down, after the `.env` file update instructions it says:

> You must use this route macro somewhere in your routes file. Replace `'mailgun-feeback'` with the url you specified at Mailgun when setting up the webhook there.

That last sentence looks a bit random there and can probably be removed?