### PR TITLE
Add warning about the cleanup-processed-feedback command when using SES

### DIFF
--- a/docs/app/installation/upgrading.md
+++ b/docs/app/installation/upgrading.md
@@ -142,6 +142,8 @@ We now suggest a new horizon configuration for balancing the queue that Mailcoac
 
 We've added a new command for cleanup of processed feedback in the `webhook_calls` table, make sure to add this to your `\App\Console\Kernel` schedule. 
 
+Be aware that email providers such as SES are a 'deliver at least once' service. Duplicate feedback delivery could be seen weeks after the event. Mailcoach prevents duplicates from SES by checking for old matching feedback. As such, cleaning up historical feedback webhooks could lead to duplicate feedbacks items being processed multiple times. The end result is inflated open and click metrics.
+
 ```php
 $schedule->command('mailcoach:cleanup-processed-feedback')->hourly();
 ```

--- a/docs/package/general/installation-and-setup.md
+++ b/docs/package/general/installation-and-setup.md
@@ -227,6 +227,8 @@ Route::mailcoach('mailcoach');
 
 In the console kernel, you should schedule these commands.
 
+Regarding the mailcoach:cleanup-processed-feedback command, be aware that email providers such as SES are a 'deliver at least once' service. Duplicate feedback delivery could be seen weeks after the event. Mailcoach prevents duplicates from SES by checking for old matching feedback. As such, cleaning up historical feedback webhooks could lead to duplicate feedbacks items being processed multiple times. The end result is inflated open and click metrics.
+
 ```php
 // in app/Console/Kernel.php
 protected function schedule(Schedule $schedule)

--- a/docs/package/general/upgrading.md
+++ b/docs/package/general/upgrading.md
@@ -142,6 +142,8 @@ We now suggest a new horizon configuration for balancing the queue that Mailcoac
 
 We've added a new command for cleanup of processed feedback in the `webhook_calls` table, make sure to add this to your `\App\Console\Kernel` schedule. 
 
+Be aware that email providers such as SES are a 'deliver at least once' service. Duplicate feedback delivery could be seen weeks after the event. Mailcoach prevents duplicates from SES by checking for old matching feedback. As such, cleaning up historical feedback webhooks could lead to duplicate feedbacks items being processed multiple times. The end result is inflated open and click metrics.
+
 ```php
 $schedule->command('mailcoach:cleanup-processed-feedback')->hourly();
 ```


### PR DESCRIPTION
Added a description of a concern regarding duplicated feedback being processed when using SES. 

I am not sure if this applies to other email providers.

The PR for duplicate prevention from SES is found here, https://github.com/spatie/laravel-mailcoach-ses-feedback/pull/2

As for formatting, not sure if this deserves a blockquote to highlight it in the docs, I didnt see blockquotes being used anywhere else in the docs so I left it as a plain paragraph.